### PR TITLE
FIx witness processing on hover

### DIFF
--- a/src/worker/worker.ts
+++ b/src/worker/worker.ts
@@ -181,17 +181,19 @@ async function handleHover(symbol: string) {
                 2
             )
 
-            const signalIndex = parseInt(line[0])
-            const b = buffWitness.slice(
-                signalIndex * wtns.n8,
-                signalIndex * wtns.n8 + wtns.n8
-            )
-            results.push(
-                "*" +
-                    parts[3].replace("main.", "") +
-                    " =* " +
-                    Scalar.fromRprLE(b).toString()
-            )
+            const signalIndex = parseInt(parts[1])
+            if (signalIndex !== -1) {
+                const b = buffWitness.slice(
+                    signalIndex * wtns.n8,
+                    signalIndex * wtns.n8 + wtns.n8
+                )
+                results.push(
+                    "*" +
+                        parts[3].replace("main.", "") +
+                        " =* " +
+                        Scalar.fromRprLE(b).toString()
+                )
+            }
 
             await fdWtns.close()
 


### PR DESCRIPTION
Looks like the witness file omits witnesses if they are only used in intermediate processing and the 2nd part of the line is actually the correct part we're looking for. Test circuit for fix:

```
pragma circom 2.0.3;

include "circomlib/poseidon.circom";
//include "https://github.com/0xPARC/circom-secp256k1/blob/master/circuits/bigint.circom";

template Example () {
    signal input a;
    signal input b;
    signal input c;
    signal d;

    d <== a * b;
    
    c === d;

    assert(a > 2);
    
    component hash = Poseidon(2);
    hash.inputs[0] <== a;
    hash.inputs[1] <== b;

    log(hash.out);
}

component main { public [ a ] } = Example();

/* INPUT = {
    "a": "5",
    "b": "77",
    "c": "385"
} */
```