### PR TITLE
Add recursive imports, add @zkemail npm imports, fix github link imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,9 @@
         "url": "git+https://github.com/antimatter15/zkrepl.git"
     },
     "author": "",
+    "engines": {
+        "node": ">=15.0.0"
+    },
     "license": "GPL-3.0",
     "bugs": {
         "url": "https://github.com/antimatter15/zkrepl/issues"

--- a/src/syntax.tsx
+++ b/src/syntax.tsx
@@ -1,5 +1,6 @@
 import * as monaco from "monaco-editor/esm/vs/editor/editor.api"
 import { circomWorker } from "./editor"
+import getLibraryUrlMap from "./worker/libraries"
 monaco.languages.register({ id: "circom" })
 
 export let replyHover = (data: any) => {}
@@ -26,13 +27,6 @@ monaco.languages.registerHoverProvider("circom", {
                         ""
                     )})`,
                 })
-            } else if (m[2].startsWith("gist:")) {
-                contents.push({
-                    value: `[View Source](https://gist.github.com/${m[2].replace(
-                        "gist:",
-                        ""
-                    )})`,
-                })
             } else if (
                 m[2].startsWith("http://") ||
                 m[2].startsWith("https://")
@@ -40,6 +34,19 @@ monaco.languages.registerHoverProvider("circom", {
                 contents.push({
                     value: `[View Source](${m[2]})`,
                 })
+            } else {
+                const libraryUrlMap = getLibraryUrlMap();
+                for (const library in libraryUrlMap) {
+                    if (m[2].startsWith(library)) {
+                        contents.push({
+                            value: `[View Source](https://${libraryUrlMap[library]}/${m[2].replace(
+                                library,
+                                ""
+                            )})`,
+                        });
+                        break;
+                    }
+                }
             }
             return {
                 range: new monaco.Range(

--- a/src/worker/libraries.ts
+++ b/src/worker/libraries.ts
@@ -4,8 +4,6 @@ export default function getLibraryUrlMap(): {[key: string]: string} {
   // allows people who skip the /circuits import in circomlib to still pass
   return {
     "gist:": "gist.github.com/",
-    "circomlib/circuits": "github.com/iden3/circomlib/blob/master/circuits",
-    "circomlib": "github.com/iden3/circomlib/blob/master/circuits",
     "@zk-email/circuits": "github.com/zkemail/zk-email-verify/tree/main/packages/circuits",
     "@zk-email/contracts": "github.com/zkemail/zk-email-verify/tree/main/packages/contracts",
     "@zk-email/helpers": "github.com/zkemail/zk-email-verify/tree/main/packages/helpers",

--- a/src/worker/libraries.ts
+++ b/src/worker/libraries.ts
@@ -1,6 +1,7 @@
 export default function getLibraryUrlMap(): {[key: string]: string} {
   return {
     "gist:": "gist.github.com/",
+    "circomlib": "github.com/iden3/circomlib/blob/master",
     "@zk-email/circuits": "github.com/zkemail/zk-email-verify/tree/main/packages/circuits",
     "@zk-email/contracts": "github.com/zkemail/zk-email-verify/tree/main/packages/contracts",
     "@zk-email/helpers": "github.com/zkemail/zk-email-verify/tree/main/packages/helpers",

--- a/src/worker/libraries.ts
+++ b/src/worker/libraries.ts
@@ -1,0 +1,9 @@
+export default function getLibraryUrlMap(): {[key: string]: string} {
+  return {
+    "gist:": "gist.github.com/",
+    "@zk-email/circuits": "github.com/zkemail/zk-email-verify/tree/main/packages/circuits",
+    "@zk-email/contracts": "github.com/zkemail/zk-email-verify/tree/main/packages/contracts",
+    "@zk-email/helpers": "github.com/zkemail/zk-email-verify/tree/main/packages/helpers",
+    "@zk-email/zk-regex-circom": "github.com/zkemail/zk-regex/tree/main/packages/circom",
+  };
+}

--- a/src/worker/libraries.ts
+++ b/src/worker/libraries.ts
@@ -1,7 +1,11 @@
 export default function getLibraryUrlMap(): {[key: string]: string} {
+  // Note that this will first process circomlib/circuits, then circomlib, so
+  // both of them will point to the same place. This is intentional, as it
+  // allows people who skip the /circuits import in circomlib to still pass
   return {
     "gist:": "gist.github.com/",
-    "circomlib": "github.com/iden3/circomlib/blob/master",
+    "circomlib/circuits": "github.com/iden3/circomlib/blob/master/circuits",
+    "circomlib": "github.com/iden3/circomlib/blob/master/circuits",
     "@zk-email/circuits": "github.com/zkemail/zk-email-verify/tree/main/packages/circuits",
     "@zk-email/contracts": "github.com/zkemail/zk-email-verify/tree/main/packages/contracts",
     "@zk-email/helpers": "github.com/zkemail/zk-email-verify/tree/main/packages/helpers",

--- a/src/worker/libraries.ts
+++ b/src/worker/libraries.ts
@@ -1,8 +1,7 @@
 export default function getLibraryUrlMap(): {[key: string]: string} {
-  // Note that this will first process circomlib/circuits, then circomlib, so
-  // both of them will point to the same place. This is intentional, as it
-  // allows people who skip the /circuits import in circomlib to still pass
-  return {
+  // Note that to avoid long circomlib import delays, those libraries are all
+  // pre-cached and not fetched from URLs. This can reduce compilation by 66% on complex circuits.
+    return {
     "gist:": "gist.github.com/",
     "@zk-email/circuits": "github.com/zkemail/zk-email-verify/tree/main/packages/circuits",
     "@zk-email/contracts": "github.com/zkemail/zk-email-verify/tree/main/packages/contracts",

--- a/src/worker/wasi.ts
+++ b/src/worker/wasi.ts
@@ -86,9 +86,7 @@ async function initFS() {
 export const wasmFsPromise = initFS()
 
 export function replaceExternalIncludes(code: string) {
-    
     console.log("Replacing external includes in file starting with", code.split('\n').slice(0, 8).join('\n'));
-    
     let finalCode = code.replace(/(include\s+")([^"]+)"/g, (all, prefix, fileName) => {
         let library_url_map = getLibraryUrlMap();
         for (let key in library_url_map) {

--- a/src/worker/wasi.ts
+++ b/src/worker/wasi.ts
@@ -90,14 +90,12 @@ export function replaceExternalIncludes(code: string) {
     let finalCode = code.replace(/(include\s+")([^"]+)"/g, (all, prefix, fileName) => {
         let library_url_map = getLibraryUrlMap();
         for (let key in library_url_map) {
-            if (fileName.startsWith(key))
-            {
-                return (
-                    prefix +
-                    fileName.replace(key, "/external/https/" + library_url_map[key]) +
-                    '"'
-                    );
+            if (fileName.startsWith(key)) {
+                return (prefix + "/external/https/" + fileName.replace(key, library_url_map[key]) + '"');
             }
+        }
+        if(fileName.startsWith("circomlib/")) {
+            return (prefix + "/" + fileName + '"');
         }
         return all.replace(/(include\s+")(\w+):\/\//, "$1/external/$2/")
     });
@@ -126,7 +124,7 @@ async function createFsBindings() {
         ...wasmFs.fs,
         openSync(path: string, flags: any) {
             // console.log("openSync>>", path, arguments)
-            const clr = path.replace(/.*circomlib\//, "circomlib/")
+            const clr = path.replace(/.*circomlib\//, "/circomlib/")
             if (path.includes("circomlib/") && wasmFs.fs.existsSync(clr))
                 path = clr;
 
@@ -134,7 +132,7 @@ async function createFsBindings() {
         },
         statSync(path: string) {
             console.log("statSync>>", path, arguments)
-            const clr = path.replace(/.*circomlib\//, "circomlib/")
+            const clr = path.replace(/.*circomlib\//, "/circomlib/")
             if (path.includes("circomlib/") && wasmFs.fs.existsSync(clr))
                 path = clr;
             

--- a/src/worker/wasi.ts
+++ b/src/worker/wasi.ts
@@ -94,6 +94,10 @@ export function replaceExternalIncludes(code: string) {
                 return (prefix + "/external/https/" + fileName.replace(key, library_url_map[key]) + '"');
             }
         }
+        // This conditional is needed to resolve https://github.com/0xPARC/zkrepl/issues/16
+        if(fileName.startsWith("circomlib/circuits/")) {
+            return (prefix + "/" + fileName.replace("circomlib/circuits/", "circomlib/") + '"');
+        }
         if(fileName.startsWith("circomlib/")) {
             return (prefix + "/" + fileName + '"');
         }

--- a/src/worker/wasi.ts
+++ b/src/worker/wasi.ts
@@ -86,7 +86,7 @@ async function initFS() {
 export const wasmFsPromise = initFS()
 
 export function replaceExternalIncludes(code: string) {
-    console.log("Replacing external includes in file starting with", code.split('\n').slice(0, 8).join('\n'));
+    // console.log("Replacing external includes in file starting with", code.split('\n').slice(0, 8).join('\n'));
     let finalCode = code.replace(/(include\s+")([^"]+)"/g, (all, prefix, fileName) => {
         let library_url_map = getLibraryUrlMap();
         for (let key in library_url_map) {
@@ -99,7 +99,7 @@ export function replaceExternalIncludes(code: string) {
         }
         return all.replace(/(include\s+")(\w+):\/\//, "$1/external/$2/")
     });
-    console.log("Final code now starting with", finalCode.split('\n').slice(0, 8).join('\n'));
+    // console.log("Final code now starting with", finalCode.split('\n').slice(0, 8).join('\n'));
     return finalCode;
 }
 

--- a/src/worker/worker.ts
+++ b/src/worker/worker.ts
@@ -29,6 +29,7 @@ type File = {
 async function initFs(files: File[]) {
     const wasmFs = await wasmFsPromise
 
+    // This is only for main.circom
     for (var file of files) {
         wasmFs.fs.writeFileSync(file.name, replaceExternalIncludes(file.value))
     }

--- a/src/worker/worker.ts
+++ b/src/worker/worker.ts
@@ -13,6 +13,7 @@ import plonkSolidityVerifierTemplate from "../data/plonk.sol?raw"
 import snarkJsTemplate from "../data/snarkjs.min.js?raw"
 import appTemplate from "../data/demo.html?raw"
 import { zKey, plonk } from "snarkjs"
+import getLibraryUrlMap from "./libraries"
 
 let wtnsFile: Uint8Array
 let filePrefix: string


### PR DESCRIPTION
Ready to merge! Preview available on https://zkemailrepl.onrender.com.

## Changes I made:
- previously only 'blob' in github links was handled right. now 'tree' in github links is handled correctly also.
- files that import other files that are all circomlib or in @zk-email packages, are imported correctly
- All external imports are at /external so relative to root. resolves the double import problem i.e. x imports y and z imports w imports y would otherwise cause a double definition of y otherwise. works for imports on different depths.
- circomlib also imported from root regardless of level of import it appears in, making complex import hierarchies still work

## Future to-dos:
- Import any npm package correctly by sourcing what the git url is automatically from npmjs, instead of one-off packages to url mapping being in this libraries.ts file.