### PR TITLE
Docs improvements

### DIFF
--- a/src/data/plonk.sol
+++ b/src/data/plonk.sol
@@ -172,7 +172,7 @@ contract PlonkVerifier {
                     acc := mulmod(acc, mload(pIn), q)
                     mstore(pIn, inv)
                 }
-                // pIn points to first element, we just set it.
+                // pIn points to the first element, we just set it.
                 mstore(pIn, acc)
             }
             

--- a/src/syntax.tsx
+++ b/src/syntax.tsx
@@ -250,7 +250,7 @@ monaco.languages.setMonarchTokensProvider("circom", {
 
             // @ annotations.
             // As an example, we emit a debugging log message on these tokens.
-            // Note: message are supressed during the first load -- change some lines to see them.
+            // Note: message are suppressed during the first load -- change some lines to see them.
             [
                 /@\s*[a-zA-Z_\$][\w\$]*/,
                 { token: "annotation", log: "annotation token: $0" },

--- a/src/worker/wasi.ts
+++ b/src/worker/wasi.ts
@@ -244,7 +244,7 @@ export async function runCircomspect(fileName = "main.circom") {
                 'P1003'
             ] as string[],
 
-            // Environment variables that are accesible to the WASI module
+            // Environment variables that are accessible to the WASI module
             env: {
                 RUST_BACKTRACE: "1",
             },


### PR DESCRIPTION
Rectify typographical inaccuracies

This PR addresses several typographical errors across various files in the project. The changes improve readability and maintain the professional standard of the documentation and code comments.

Justification
Typographical errors, while minor, can detract from the overall quality of the project. Correcting these errors ensures clarity and professionalism, making the project more accessible and understandable for current and future contributors.