### PR TITLE
Typos fix

### DIFF
--- a/src/data/groth16.sol
+++ b/src/data/groth16.sol
@@ -7,7 +7,7 @@
 // 2019 OKIMS
 //      ported to solidity 0.6
 //      fixed linter warnings
-//      added requiere error messages
+//      added require error messages
 //
 //
 // SPDX-License-Identifier: GPL-3.0

--- a/src/data/plonk.sol
+++ b/src/data/plonk.sol
@@ -142,7 +142,7 @@ contract PlonkVerifier {
     
                 let pAux := mload(0x40)     // Point to the next free position
                 let pIn := pVals
-                let lastPIn := add(pVals, mul(n, 32))  // Read n elemnts
+                let lastPIn := add(pVals, mul(n, 32))  // Read n elements
                 let acc := mload(pIn)       // Read the first element
                 pIn := add(pIn, 32)         // Point to the second element
                 let inv

--- a/src/syntax.tsx
+++ b/src/syntax.tsx
@@ -250,7 +250,7 @@ monaco.languages.setMonarchTokensProvider("circom", {
 
             // @ annotations.
             // As an example, we emit a debugging log message on these tokens.
-            // Note: message are supressed during the first load -- change some lines to see them.
+            // Note: message are suppressed during the first load -- change some lines to see them.
             [
                 /@\s*[a-zA-Z_\$][\w\$]*/,
                 { token: "annotation", log: "annotation token: $0" },


### PR DESCRIPTION
# Fix: Corrected typos in comments

## What was changed
- Corrected typos  to improve clarity and professionalism.

## Why these changes were made
- Fixing typos enhances the clarity and readability of the codebase, making it more professional and easier to understand.

## Additional Notes
- These changes focus solely on correcting typographical errors in comments and do not affect the functionality of the code.