### PR TITLE
code-Update wasi.ts

### DIFF
--- a/src/worker/wasi.ts
+++ b/src/worker/wasi.ts
@@ -51,7 +51,7 @@ const browserBindings = {
 
 async function loadWasm(url: string) {
     const response = await fetch(url)
-    const contentType = response.headers.get("Content-Type") || ""
+    const contentType = response.headers.get("Content-Type") ?? ""
     if (
         "instantiateStreaming" in WebAssembly &&
         contentType.startsWith("application/wasm")


### PR DESCRIPTION
# Fix: Replaced logical OR (`||`) with nullish coalescing operator (`??`)

## Changes
- Updated `src/worker/wasi.ts:54` to use the nullish coalescing operator (`??`) for safer fallback handling.

  - **Before**:
    ```typescript
    const contentType = response.headers.get("Content-Type") || "";
    ```

  - **After**:
    ```typescript
    const contentType = response.headers.get("Content-Type") ?? "";
    ```

## Purpose
- Ensured safer fallback behavior by using the nullish coalescing operator, which only falls back for `null` or `undefined`.

